### PR TITLE
Added boot disk size and type variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,8 @@ resource "google_compute_instance" "vm_instance" {
   tags         = local.tags
   boot_disk {
     initialize_params {
+      size  = var.boot_disk_size
+      type  = var.boot_disk_type
       image = var.boot_disk_image_source
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -70,3 +70,15 @@ variable "allow_stopping_for_update" {
   type        = bool
   default     = true
 }
+
+variable "boot_disk_size" {
+  description = "The size of the image in gigabytes."
+  type        = number
+  default     = 10
+}
+
+variable "boot_disk_type" {
+  description = "The GCE disk type. May be set to pd-standard, pd-balanced or pd-ssd"
+  type        = string
+  default     = "pd-standard"
+}


### PR DESCRIPTION
Added boot disk size and type variable in `initialize_params` block of GCE Terraform.

**How does it work?**
Now while creating Google Compute Instance module from main.tf file, we do need to pass the value of `boot_disk_type` & `boot_disk_size (GiB)`. Adding these two variables allows user to pass desired values according to the need.
These two values are optional parameter meaning.

**How the existing solution doesn't work?**
With an existing solution, we do not any option to pass the non-default value of  `boot_disk_type` & `boot_disk_size` so the resource being created will be of default values only. PD-Standard in case of `boot_disk_type` & 10 GiB in `boot_disk_size`.