### PR TITLE
Added lifecycle block in main.tf and 3 outputs attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "google_compute_instance" "vm_instance" {
   depends_on                = [google_project_service.compute_api]
   lifecycle {
     ignore_changes = [
+      attached_disks,
       metadata["windows-keys"],
     ]
   }

--- a/main.tf
+++ b/main.tf
@@ -47,4 +47,7 @@ resource "google_compute_instance" "vm_instance" {
   }
   allow_stopping_for_update = var.allow_stopping_for_update
   depends_on                = [google_project_service.compute_api]
+  lifecycle {
+    ignore_changes = [attached_disk]
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,8 @@ output "instance_id" {
   description = "The server-assigned unique identifier of this instance."
   value       = google_compute_instance.vm_instance.instance_id
 }
+
+output "instance_name" {
+  description = "The generated name of the GCloud VM Instance"
+  value       = local.instance_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,18 @@ output "static_ip" {
   description = "The static IP address attached to the VM instance."
   value       = local.static_ip
 }
+
+output "self_link" {
+  description = "The URI of the created resource."
+  value       = google_compute_instance.vm_instance.self_link
+}
+
+output "id" {
+  description = "an identifier for the resource with format projects/{{project}}/zones/{{zone}}/instances/{{name}}"
+  value       = google_compute_instance.vm_instance.id
+}
+
+output "instance_id" {
+  description = "The server-assigned unique identifier of this instance."
+  value       = google_compute_instance.vm_instance.instance_id
+}


### PR DESCRIPTION
Added lifecycle block in main.tf and 3 outputs attributes

**How does it work?**
With these outputs, we can reference the GCP VM in other modules.

`lifecycle.ignore_changes = ["attached_disk"]` are required in case we attaching an additional disk to VM Instance if we are creating a separate module for an additional disk. Otherwise, the two resources will fight for control of the attached disk block.

**How the existing solution doesn't work?**
Right now, there are no output attributes in the GCP VM Instance module through which we can reference VM instance required in other modules like if we are attaching an additional disk to VM, we can't do it.
