### PR TITLE
Updated main.tf with attached_disks block & added instance_name output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "google_project_service" "compute_api" {
 module "service_account" {
   count        = local.create_new_sa ? 1 : 0
   source       = "airasia/service_account/google"
-  version      = "2.0.0"
+  version      = "2.0.1"
   name_suffix  = var.name_suffix
   name         = local.sa_name
   display_name = local.sa_name

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "google_compute_instance" "vm_instance" {
   depends_on                = [google_project_service.compute_api]
   lifecycle {
     ignore_changes = [
+      attached_disks,
       metadata["windows-keys"],
     ]
   }

--- a/main.tf
+++ b/main.tf
@@ -47,4 +47,7 @@ resource "google_compute_instance" "vm_instance" {
   }
   allow_stopping_for_update = var.allow_stopping_for_update
   depends_on                = [google_project_service.compute_api]
+  lifecycle {
+    ignore_changes = [attached_disk]
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,16 +19,16 @@ output "self_link" {
 }
 
 output "id" {
-  description = "an identifier for the resource with format projects/{{project}}/zones/{{zone}}/instances/{{name}}"
+  description = "An identifier for the resource with format projects/{{project}}/zones/{{zone}}/instances/{{name}}"
   value       = google_compute_instance.vm_instance.id
 }
 
 output "instance_id" {
-  description = "The server-assigned unique identifier of this instance."
+  description = "The server-assigned 19 digits unique identifier of this instance. Example: 4567719474035761998"
   value       = google_compute_instance.vm_instance.instance_id
 }
 
 output "instance_name" {
-  description = "The generated name of the GCloud VM Instance"
+  description = "The generated name of the GCloud VM Instance with format {{instance-name}}-vm-{{suffix with 4 characters random string separated with -}}. Example: vm-instance-tf-1a2b"
   value       = local.instance_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,8 @@ output "instance_id" {
   description = "The server-assigned unique identifier of this instance."
   value       = google_compute_instance.vm_instance.instance_id
 }
+
+output "instance_name" {
+  description = "The generated name of the GCloud VM Instance"
+  value       = local.instance_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "sa_email" {
   description = "Email address of the ServiceAccount that is attached to the VM instance."
   value       = local.vm_sa_email
 }
+
+output "sa_roles" {
+  description = "All roles (except sensitive roles filtered by the module) that are attached to the ServiceAccount of this VM."
+  value       = module.service_account.roles
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,18 @@ output "static_ip" {
   description = "The static IP address attached to the VM instance."
   value       = local.static_ip
 }
+
+output "self_link" {
+  description = "The URI of the created resource."
+  value       = google_compute_instance.vm_instance.self_link
+}
+
+output "id" {
+  description = "an identifier for the resource with format projects/{{project}}/zones/{{zone}}/instances/{{name}}"
+  value       = google_compute_instance.vm_instance.id
+}
+
+output "instance_id" {
+  description = "The server-assigned unique identifier of this instance."
+  value       = google_compute_instance.vm_instance.instance_id
+}


### PR DESCRIPTION
Updated `main.tf` with attached_disks block & added *instance_name* output

Added one more block in `lifecycle.ignore_changes`, i.e. as it will be required at the time of attaching an additional disk to GCP Virtual Machines.

Added `instance_name` output variable in `outputs.tf` file. We need this output for naming convention of VM related services like disk management.

I've tested these changes locally, they are working properly.