### PR TITLE
We have fixed the instance_name output variable

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -37,7 +37,7 @@ output "instance_id" {
 
 output "instance_name" {
   description = "The generated name of the GCloud VM Instance. Example: myubuntu2010-vm-tfa2c4"
-  value       = local.instance_name
+  value       = format("%s-%s", local.instance_name, var.name_suffix)
 }
 
 output "zone" {


### PR DESCRIPTION
Hi team,

We have used your module and when we used the instance_name output variable, the value is incorrect because only show the local.instance_name variable.

The correct value for this output we think is:
format("%s-%s", local.instance_name, var.name_suffix)

Please, tell us if we're wrong