### PR TITLE
Introduction of fw_allowed_ports and fw_allowed_cidrs variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,19 +106,19 @@ resource "google_compute_firewall" "login_to_vm" {
   network     = google_compute_instance.vm_instance.network_interface.0.network
   target_tags = local.network_tags
   source_ranges = distinct(concat(
-      [local.google_iap_cidr /* see https://stackoverflow.com/a/57024714/636762 */],
-      var.fw_allowed_cidrs
+    [local.google_iap_cidr /* see https://stackoverflow.com/a/57024714/636762 */],
+    var.fw_allowed_cidrs
   ))
   depends_on = [google_project_service.networking_api]
   allow {
     protocol = "tcp"
     ports = distinct(concat(
-        [
-          # https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule
-          22,   # for SSH
-          3389, # for RDP
-        ],
-        var.fw_allowed_ports
+      # https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule
+      [
+        22,   # for SSH
+        3389, # for RDP
+      ],
+      var.fw_allowed_ports
     ))
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -105,23 +105,20 @@ resource "google_compute_firewall" "login_to_vm" {
   name        = local.vm_login_firewall_name
   network     = google_compute_instance.vm_instance.network_interface.0.network
   target_tags = local.network_tags
-  source_ranges = distinct(
-    concat(
-      [
-        local.google_iap_cidr /* see https://stackoverflow.com/a/57024714/636762 */
-      ],
-      (var.fw_allowed_cidrs)
+  source_ranges = distinct(concat(
+      [local.google_iap_cidr /* see https://stackoverflow.com/a/57024714/636762 */],
+      var.fw_allowed_cidrs
   ))
   depends_on = [google_project_service.networking_api]
   allow {
     protocol = "tcp"
-    ports = distinct(
-      concat(
+    ports = distinct(concat(
         [
-          "22",  # ssh
-          "3389" # rdp
+          # https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule
+          22,   # for SSH
+          3389, # for RDP
         ],
-        (var.fw_allowed_ports)
+        var.fw_allowed_ports
     ))
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ locals {
   create_firewalls        = length(local.network_tags) > 0 ? true : false
   vm_login_firewall_name  = format("login-to-%s-%s", local.instance_name, var.name_suffix)
   vm_egress_firewall_name = format("%s-to-network-%s", local.instance_name, var.name_suffix)
+  google_iap_cidr         = "35.235.240.0/20" # GCloud Identity Aware Proxy Netblock - https://cloud.google.com/iap/docs/using-tcp-forwarding#preparing_your_project_for_tcp_forwarding
 }
 
 resource "google_project_service" "compute_api" {
@@ -103,12 +104,12 @@ resource "google_compute_firewall" "login_to_vm" {
   count         = (local.create_firewalls && var.allow_login) ? 1 : 0
   name          = local.vm_login_firewall_name
   network       = google_compute_instance.vm_instance.network_interface.0.network
-  source_ranges = distinct(var.fw_allowed_cidrs)
+  source_ranges = concat([local.google_iap_cidr /* see https://stackoverflow.com/a/57024714/636762 */], distinct(var.fw_allowed_cidrs))
   target_tags   = local.network_tags
   depends_on    = [google_project_service.networking_api]
   allow {
     protocol = "tcp"
-    ports    = distinct(var.fw_allowed_ports)
+    ports    = concat(["22", "3389"], distinct(var.fw_allowed_ports))
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,7 @@ variable "login_service_accounts" {
 }
 
 variable "fw_allowed_cidrs" {
-  description = "List of source IP address of particular range to which the firewall rule will apply. These ranges must be expressed in CIDR format."
+  description = "List of IP CIDRs to be allowed  by the VM firewall rules for incoming traffic."
   type        = list(string)
   default     = ["35.235.240.0/20"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -134,11 +134,11 @@ variable "login_service_accounts" {
 variable "fw_allowed_cidrs" {
   description = "List of IP CIDRs to be allowed  by the VM firewall rules for incoming traffic."
   type        = list(string)
-  default     = ["35.235.240.0/20"]
+  default     = []
 }
 
 variable "fw_allowed_ports" {
   description = "List of ports to be opened by the VM firewall rules for incoming traffics to connect to."
   type        = list(string)
-  default     = ["22", "3389"]
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -130,3 +130,15 @@ variable "login_service_accounts" {
   type        = list(string)
   default     = []
 }
+
+variable "fw_allowed_cidrs" {
+  description = "List of source IP address of particular range to which the firewall rule will apply. These ranges must be expressed in CIDR format."
+  type        = list(string)
+  default     = ["35.235.240.0/20"]
+}
+
+variable "fw_allowed_ports" {
+  description = "List of ports to which this rule applies."
+  type        = list(string)
+  default     = ["22", "3389"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,7 @@ variable "login_service_accounts" {
 }
 
 variable "fw_allowed_cidrs" {
-  description = "List of IP CIDRs to be allowed  by the VM firewall rules for incoming traffic."
+  description = "List of IP CIDRs to be allowed by the VM firewall rules for incoming traffic."
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -138,7 +138,7 @@ variable "fw_allowed_cidrs" {
 }
 
 variable "fw_allowed_ports" {
-  description = "List of ports to which this rule applies."
+  description = "List of ports to be opened by the VM firewall rules for incoming traffics to connect to."
   type        = list(string)
   default     = ["22", "3389"]
 }


### PR DESCRIPTION
Add **fw_allowed_ports** and **fw_allowed_cidrs** variables for GCE Firewall allow.ports and source_ranges arguments respectively.

### How existing solution doesn't work?
With the existing solution, we cannot add additional ports and CIDR ranges if needed since the values are hardcoded in module. We have to do it manually which will eventually delete whenever the next terraform runs.

### How new solution works?
In new solution, I've introduced two new optional variables `fw_allowed_ports` and `fw_allowed_cidrs` variables for GCE Firewall **allow.ports** and **source_ranges** arguments respectively. The default and required value(s) of these two variables are supplying through a module and getting concatted. With this if any application/jobs deployed in GCE VM needs additional CIDR ranges and ports to be whitelisted, addition of values simply in parent module will work.

I've used terraform's distinct function with variables to remove any duplicate ports or IP add.

### Example

```
module "testing_vm" {
  source           = "airasia/vm_instance/google"
  name_suffix      = local.name_suffix
  . . .
  fw_allowed_cidrs = ["xx.xx.xx.xx/16", "yy.yy.yy.yy/32", "127.0.0.1/32"]
  fw_allowed_ports = ["8080"]
}
```

The codes are tested and working as expected.